### PR TITLE
Fixed Presigned URLs

### DIFF
--- a/Sources/S3Signer/S3Signer+Private.swift
+++ b/Sources/S3Signer/S3Signer+Private.swift
@@ -72,8 +72,8 @@ extension S3Signer {
             let signHeaders = signed(headers: headers).encode(type: .queryAllowed) else {
                 throw Error.invalidEncoding
         }
-        let fullURL = "\(url.absoluteString)?x-amz-algorithm=AWS4-HMAC-SHA256&x-amz-credential=\(config.accessKey)%2F\(credScope)&x-amz-date=\(dates.long)&x-amz-expires=\(expiration.value)&x-amz-signedheaders=\(signHeaders)"
-        
+        let fullURL = "\(url.absoluteString)?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=\(config.accessKey)%2F\(credScope)&X-Amz-Date=\(dates.long)&X-Amz-Expires=\(expiration.value)&X-Amz-SignedHeaders=\(signHeaders)"
+
         // This should never throw.
         guard let url = URL(string: fullURL) else {
             throw Error.badURL(fullURL)
@@ -133,7 +133,7 @@ extension S3Signer {
 
         let stringToSign = try createStringToSign(canonRequest, dates: dates, region: region)
         let signature = try createSignature(stringToSign, timeStampShort: dates.short, region: region)
-        let presignedURL = URL(string: fullURL.absoluteString.appending("&x-amz-signature=\(signature)"))
+        let presignedURL = URL(string: fullURL.absoluteString.appending("&X-Amz-Signature=\(signature)"))
         return presignedURL
     }
 


### PR DESCRIPTION
The issue was that the AWS query keys are case sensitive. Making this match the documentation fixed it. 