### PR TITLE
Added support for prefix filtering in bucket list

### DIFF
--- a/Sources/S3/Protocols/S3Client.swift
+++ b/Sources/S3/Protocols/S3Client.swift
@@ -29,9 +29,12 @@ public protocol S3Client: Service {
     
     /// Get list of objects
     func list(bucket: String, region: Region?, on container: Container) throws -> Future<BucketResults>
-    
+
     /// Get list of objects
-    func list(bucket: String, region: Region?, headers: [String: String], on container: Container) throws -> Future<BucketResults>
+    func list(bucket: String, region: Region?, prefix: String?, delimiter: String?, on container: Container) throws -> Future<BucketResults>
+
+    /// Get list of objects
+    func list(bucket: String, region: Region?, headers: [String: String], prefix: String?, delimiter: String?, on container: Container) throws -> Future<BucketResults>
     
     /// Upload file to S3
     func put(file: File.Upload, on container: Container) throws -> EventLoopFuture<File.Response>

--- a/Sources/S3DemoApp/S3DemoApp.swift
+++ b/Sources/S3DemoApp/S3DemoApp.swift
@@ -42,7 +42,7 @@ public func routes(_ router: Router) throws {
     // Delete bucket
     router.get("files")  { req -> Future<BucketResults> in
         let s3 = try req.makeS3Client()
-        return try s3.list(bucket: "booststore", region: .usEast1, headers: [:], on: req).catchMap({ (error) -> (BucketResults) in
+        return try s3.list(bucket: "booststore", region: .usEast1, on: req).catchMap({ (error) -> (BucketResults) in
             if let error = error.s3ErrorMessage() {
                 print(error.message)
             }


### PR DESCRIPTION
This adds new parameters to the `list` function to enable support for prefix filtering when listing contents of buckets