### PR TITLE
Make objects in BucketResults optional 

### DIFF
--- a/Sources/S3/Models/BucketResults.swift
+++ b/Sources/S3/Models/BucketResults.swift
@@ -49,7 +49,7 @@ public struct BucketResults: Content {
     public let isTruncated: Bool
     
     /// Objects
-    public let objects: [Object]
+    public let objects: [Object]?
     
     enum CodingKeys: String, CodingKey {
         case name = "Name"


### PR DESCRIPTION
If you list a bucket and it has no content there is no `content` tag in the result which causes an error as the `objects` property of `BucketResults` cannot be populated.  This is solved by making `objects` optional.